### PR TITLE
fix redirect issue with easing

### DIFF
--- a/js/freelancer.js
+++ b/js/freelancer.js
@@ -6,7 +6,7 @@
 
 // jQuery for page scrolling feature - requires jQuery Easing plugin
 $(function() {
-    $('.page-scroll a').bind('click', function(event) {
+    $('body').on('click', '.page-scroll a', function(event) {
         var $anchor = $(this);
         $('html, body').stop().animate({
             scrollTop: $($anchor.attr('href')).offset().top


### PR DESCRIPTION
Currently in the application I'm working on with this theme I use GitHub OAuth2 which redirects after a successful authorization. When GitHub (or any OAuth protocol) redirects this function executes before .page-scroll a is visible in the DOM regardless of document.ready. The click handler should be bound to the listen on the body for clicks to .page-scroll a instead. While this might be a little more expensive than binding to the actual element it fixes a pretty large problem IMO. It's a double edged sword because either you sacrifice a little bit of optimization or easing breaks when a server redirects the app. Even though I realize this is supposed to be a single page template I think login/OAuth is the one exception.
