### PR TITLE
Run less before minift-css

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ gulp.task('less', function() {
 });
 
 // Minify CSS
-gulp.task('minify-css', function() {
+gulp.task('minify-css', ['less'], function() {
     return gulp.src('css/freelancer.css')
         .pipe(cleanCSS({ compatibility: 'ie8' }))
         .pipe(rename({ suffix: '.min' }))


### PR DESCRIPTION
Sometimes minify-css can run before less since they are parallel tasks
Make minify-css wait for the completion of less so the freelancer.min.css file is always generated.
Otherwise gulp needs to be run twice to ensure an updated *.min.css file