### PR TITLE
add script section in package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "type": "MIT",
     "url": "https://github.com/BlackrockDigital/startbootstrap/blob/gh-pages/LICENSE"
   },
+    "scripts": {
+    "build": "node node_modules/gulp/bin/gulp.js",
+    "dev": "node node_modules/gulp/bin/gulp.js dev"
+  },
   "devDependencies": {
     "bootstrap": "^3.3.7",
     "browser-sync": "^2.13.0",


### PR DESCRIPTION
Add a script section in package.json file so that we can use the node script feature. This allow to use the embedded version of gulp natively.

gulp is installed locally due to its mention in package.json file, it should be easy to use gulp without to type the whole path. Using the node script feature, it is now possible to use the following commands :
- to run the _build_ task of gulp

``` bash
npm run build
```
- to run the _dev_ task of gulp

``` bash
npm run dev
```
