### PR TITLE
Moving the 'btnSubmit' ID to the contact form button

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
                         <div id="success"></div>
                         <div class="row">
                             <div class="form-group col-xs-12">
-                                <button type="submit" class="btn btn-success btn-lg">Send</button>
+                                <button type="submit" class="btn btn-success btn-lg" id="btnSubmit">Send</button>
                             </div>
                         </div>
                     </form>
@@ -508,7 +508,7 @@
                                     </strong>
                                 </li>
                             </ul>
-                            <button id="btnSubmit" type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-times"></i> Close</button>
+                            <button type="button" class="btn btn-default" data-dismiss="modal"><i class="fa fa-times"></i> Close</button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
The commit associated with [this pull request](https://github.com/BlackrockDigital/startbootstrap-freelancer/pull/115) incorrectly added the btnSubmit id to a button not associated with the contact form.

This pull request simply moves the id accordingly.