### PR TITLE
textarea should not contain type attribute

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -189,7 +189,7 @@
                             </div>
                             <!-- Message input-->
                             <div class="form-floating mb-3">
-                                <textarea class="form-control" id="message" type="text" placeholder="Enter your message here..." style="height: 10rem" data-sb-validations="required"></textarea>
+                                <textarea class="form-control" id="message" placeholder="Enter your message here..." style="height: 10rem" data-sb-validations="required"></textarea>
                                 <label for="message">Message</label>
                                 <div class="invalid-feedback" data-sb-feedback="message:required">A message is required.</div>
                             </div>


### PR DESCRIPTION
The type parameter causes https://www.html-tidy.org to issue the warning proprietary attribute type; and type does not seem to be a valid attribute for textarea